### PR TITLE
First simple fix to allow edge-to-edge layout

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,6 +14,7 @@
             <com.google.android.material.appbar.AppBarLayout
                 android:id="@+id/appbar"
                 android:layout_width="match_parent"
+                android:fitsSystemWindows="true"
                 android:layout_height="wrap_content"
                 app:layout_constraintBottom_toTopOf="@+id/main_activity_nav_fragment"
                 app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
SDK Level 35 enforces edge-to-edge layout which we didn't support until now. This adds simple support, but has still some rough edges. For example if the app background and the status bar icons are the same color they aren't visible