### PR TITLE
Add button to remove endpoint

### DIFF
--- a/app/src/main/java/org/d3kad3nt/sunriseClock/data/remote/deconz/DeconzEndpoint.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/data/remote/deconz/DeconzEndpoint.java
@@ -23,6 +23,8 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 import okhttp3.Interceptor;
@@ -137,6 +139,26 @@ public class DeconzEndpoint extends BaseEndpoint {
             .create(IServices.class);
 
         return this;
+    }
+
+    private URI createUri() {
+        URI providedURI = URI.create(baseUrl);
+        String scheme = providedURI.getScheme();
+        if (scheme == null) {
+            scheme = "http";
+        }
+        String host = providedURI.getHost();
+        if (host == null) {
+            // URLs like test.com are parsed as if they have no host and test.com is a path
+            host = providedURI.getPath();
+        }
+        String path = String.format("/api/%s/", apiKey);
+        try {
+            return new URI(scheme, null, host, port, path, null, null);
+        }
+        catch (URISyntaxException e) {
+            throw new IllegalArgumentException("URI can't be parsed", e);
+        }
     }
 
     @Override

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/data/repository/EndpointRepository.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/data/repository/EndpointRepository.java
@@ -19,6 +19,7 @@ import org.d3kad3nt.sunriseClock.data.model.endpoint.UIEndpoint;
 import org.d3kad3nt.sunriseClock.data.remote.common.EndpointBuilder;
 import org.d3kad3nt.sunriseClock.serviceLocator.ExecutorType;
 import org.d3kad3nt.sunriseClock.serviceLocator.ServiceLocator;
+import org.d3kad3nt.sunriseClock.util.LiveDataUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -109,5 +110,9 @@ public class EndpointRepository {
         });
         type.getBuilder().setConfig(endpointConfig).build();
         return UIEndpoint.from(endpointConfig);
+    }
+
+    public void deleteEndpoint(long endpoint) {
+        LiveDataUtil.observeOnce(endpointConfigDao.load(endpoint), endpointConfigDao::delete);
     }
 }

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/data/repository/EndpointRepository.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/data/repository/EndpointRepository.java
@@ -113,6 +113,12 @@ public class EndpointRepository {
     }
 
     public void deleteEndpoint(long endpoint) {
-        LiveDataUtil.observeOnce(endpointConfigDao.load(endpoint), endpointConfigDao::delete);
+        LiveDataUtil.observeOnce(
+            endpointConfigDao.load(endpoint),endpointConfig -> {
+                ServiceLocator.getExecutor(ExecutorType.IO).execute(() -> {
+                    endpointConfigDao.delete(endpointConfig);
+                });
+            }
+        );
     }
 }

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/data/repository/EndpointRepository.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/data/repository/EndpointRepository.java
@@ -33,6 +33,7 @@ public class EndpointRepository {
     private static final Map<Long, LiveData<BaseEndpoint>> endpointLiveDataCache = new HashMap<>();
     private static EndpointConfigDao endpointConfigDao;
     private static volatile EndpointRepository INSTANCE;
+    private static final String TAG = EndpointRepository.class.getSimpleName();
 
     private EndpointRepository(Context context) {
         endpointConfigDao = AppDatabase.getInstance(context.getApplicationContext()).endpointConfigDao();

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailFragment.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailFragment.java
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.d3kad3nt.sunriseClock.databinding.EndpointDetailFragmentBinding;
+import org.d3kad3nt.sunriseClock.util.LiveDataUtil;
 
 public class EndpointDetailFragment extends Fragment {
 
@@ -32,7 +33,20 @@ public class EndpointDetailFragment extends Fragment {
             new EndpointDetailViewModelFactory(requireActivity().getApplication(), endpointID)).get(
             EndpointDetailViewModel.class);
         binding = EndpointDetailFragmentBinding.inflate(inflater, container, false);
+        addDeleteEndpointListener(binding);
         return binding.getRoot();
+    }
+
+    private void addDeleteEndpointListener(final EndpointDetailFragmentBinding binding) {
+        binding.deleteEndpoint.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                LiveDataUtil.observeOnce(viewModel.endpointConfig,iEndpointUI -> {
+                    viewModel.deleteEndpoint();
+                });
+            }
+
+        });
     }
 
     @Override

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailFragment.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailFragment.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.Navigation;
 
 import org.d3kad3nt.sunriseClock.databinding.EndpointDetailFragmentBinding;
 import org.d3kad3nt.sunriseClock.util.LiveDataUtil;
@@ -43,6 +44,7 @@ public class EndpointDetailFragment extends Fragment {
             public void onClick(View v) {
                 LiveDataUtil.observeOnce(viewModel.endpointConfig,iEndpointUI -> {
                     viewModel.deleteEndpoint();
+                    Navigation.findNavController(v).navigateUp();
                 });
             }
 

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailFragment.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailFragment.java
@@ -43,11 +43,11 @@ public class EndpointDetailFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 LiveDataUtil.observeOnce(viewModel.endpointConfig,iEndpointUI -> {
-                    viewModel.deleteEndpoint();
-                    Navigation.findNavController(v).navigateUp();
+                    if (viewModel.deleteEndpoint()) {
+                        Navigation.findNavController(v).navigateUp();
+                    }
                 });
             }
-
         });
     }
 

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailViewModel.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailViewModel.java
@@ -39,7 +39,6 @@ public class EndpointDetailViewModel extends AndroidViewModel {
     }
 
     public boolean deleteEndpoint() {
-        endpointRepository.deleteEndpoint(endpointId);
         final AtomicBoolean result = new AtomicBoolean(false);
         LivePreference<Long> selectedEndpoint = settingsRepository.getLongSetting("endpoint_id", 0);
         LiveDataUtil.observeOnce(selectedEndpoint, selectedEndpointId -> {

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailViewModel.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailViewModel.java
@@ -30,5 +30,6 @@ public class EndpointDetailViewModel extends AndroidViewModel {
 
     public void deleteEndpoint() {
         endpointRepository.deleteEndpoint(endpointId);
+
     }
 }

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailViewModel.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailViewModel.java
@@ -16,13 +16,19 @@ public class EndpointDetailViewModel extends AndroidViewModel {
         EndpointRepository.getInstance(getApplication().getApplicationContext());
 
     public LiveData<IEndpointUI> endpointConfig;
+    private final long endpointId;
 
     public EndpointDetailViewModel(@NonNull Application application, long endpointId) {
         super(application);
         endpointConfig = getEndpoint(endpointId);
+        this.endpointId = endpointId;
     }
 
     private LiveData<IEndpointUI> getEndpoint(long endpointID) {
         return endpointRepository.getEndpoint(endpointID);
+    }
+
+    public void deleteEndpoint() {
+        endpointRepository.deleteEndpoint(endpointId);
     }
 }

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailViewModel.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/ui/endpoint/endpointDetail/EndpointDetailViewModel.java
@@ -1,6 +1,7 @@
 package org.d3kad3nt.sunriseClock.ui.endpoint.endpointDetail;
 
 import android.app.Application;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
@@ -8,12 +9,20 @@ import androidx.lifecycle.LiveData;
 
 import org.d3kad3nt.sunriseClock.data.model.endpoint.IEndpointUI;
 import org.d3kad3nt.sunriseClock.data.repository.EndpointRepository;
+import org.d3kad3nt.sunriseClock.data.repository.SettingsRepository;
+import org.d3kad3nt.sunriseClock.util.LiveDataUtil;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import me.ibrahimsn.library.LivePreference;
 
 public class EndpointDetailViewModel extends AndroidViewModel {
 
     private final static String TAG = "EndpointDetailViewModel";
     private final EndpointRepository endpointRepository =
         EndpointRepository.getInstance(getApplication().getApplicationContext());
+    private  final SettingsRepository settingsRepository =
+        SettingsRepository.getInstance(getApplication().getApplicationContext());
 
     public LiveData<IEndpointUI> endpointConfig;
     private final long endpointId;
@@ -21,6 +30,7 @@ public class EndpointDetailViewModel extends AndroidViewModel {
     public EndpointDetailViewModel(@NonNull Application application, long endpointId) {
         super(application);
         endpointConfig = getEndpoint(endpointId);
+
         this.endpointId = endpointId;
     }
 
@@ -28,8 +38,18 @@ public class EndpointDetailViewModel extends AndroidViewModel {
         return endpointRepository.getEndpoint(endpointID);
     }
 
-    public void deleteEndpoint() {
+    public boolean deleteEndpoint() {
         endpointRepository.deleteEndpoint(endpointId);
-
+        final AtomicBoolean result = new AtomicBoolean(false);
+        LivePreference<Long> selectedEndpoint = settingsRepository.getLongSetting("endpoint_id", 0);
+        LiveDataUtil.observeOnce(selectedEndpoint, selectedEndpointId -> {
+            Log.d(TAG, "selected id: " + selectedEndpointId + " current id:" + endpointId);
+            if (selectedEndpointId != endpointId){
+                Log.d(TAG, "delete endpoint");
+                endpointRepository.deleteEndpoint(endpointId);
+                result.set(true);
+            }
+        });
+        return result.get();
     }
 }

--- a/app/src/main/res/layout/endpoint_add_deconz_fragment.xml
+++ b/app/src/main/res/layout/endpoint_add_deconz_fragment.xml
@@ -37,6 +37,7 @@
             android:hint="@string/port"
             app:helperText="Format: 80"
             app:helperTextEnabled="true"
+            android:text="80"
             app:layout_constraintBottom_toTopOf="@id/editTextApikeyContainer"
             app:layout_constraintLeft_toRightOf="@id/guideline"
             app:layout_constraintRight_toRightOf="parent">
@@ -44,7 +45,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="numberDecimal"
-                android:tag="port" />
+                android:tag="port"
+                android:text="80" />
         </com.google.android.material.textfield.TextInputLayout>
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/editTextApikeyContainer"

--- a/app/src/main/res/layout/endpoint_detail_fragment.xml
+++ b/app/src/main/res/layout/endpoint_detail_fragment.xml
@@ -9,7 +9,7 @@
     </data>
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         tools:context="org.d3kad3nt.sunriseClock.ui.endpoint.endpointDetail.EndpointDetailFragment">
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/list_endpoint_name"
@@ -19,5 +19,16 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="@sample/sample.json/endpoints/name" />
+        <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+            android:id="@+id/deleteEndpoint"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|bottom"
+            android:layout_margin="16dp"
+            android:contentDescription="@string/delete"
+            android:text="@string/delete"
+            app:icon="@drawable/ic_plus"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -64,4 +64,5 @@
     <string name="light_on_state_label">Angeschaltet</string>
     <string name="light_brightness_label">Helligkeit</string>
     <string name="light_not_reachable">Licht kann nicht erreicht werden</string>
+    <string name="delete">Löschen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,7 +56,7 @@
     <string name="lights_title">All Lights</string>
     <string name="lightDetail_title">Light info</string>
     <string name="preferences_title">Preferences</string>
-    <string name="conectivity_settings_title">Conectivity</string>
+    <string name="conectivity_settings_title">Connectivity</string>
     <string name="alarm_settings_title">Alarm</string>
     <string name="debug_settings_title">Debug</string>
     <string name="interface_settings_title">Interface</string>
@@ -71,4 +71,5 @@
     <string name="light_on_state_label">Light State</string>
     <string name="light_brightness_label">Brightness</string>
     <string name="light_not_reachable">Light is not reachable</string>
+    <string name="delete">Delete</string>
 </resources>


### PR DESCRIPTION
This adds a button to the endpoint details page that deletes the current endpoint.
If the current endpoint is the selected endpoint the endpoint can't be deleted.

This uses a simple UI, because the real UI should be added, after we migrated to Material 3.