### PR TITLE
Fix warning regarding android:fullBackupContent.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,16 +6,13 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
-        android:allowBackup="true"
-        android:fullBackupContent="@xml/backup_descriptor"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true"
-        tools:ignore="GoogleAppIndexingWarning"
-        tools:targetApi="m">
+        tools:targetApi="23">
         <activity
             android:name=".ui.MainActivity"
             android:exported="true">
@@ -41,7 +38,7 @@
             android:exported="true"
             android:label="Deconz Sunrise Clock"
             android:permission="android.permission.BIND_CONTROLS"
-            tools:targetApi="r">
+            tools:targetApi="30">
             <intent-filter>
                 <action android:name="android.service.controls.ControlsProviderService" />
             </intent-filter>

--- a/app/src/main/res/xml/backup_descriptor.xml
+++ b/app/src/main/res/xml/backup_descriptor.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<full-backup-content>
-    <!-- Exclude the shared preferences_main file that contains the GCM registrationId -->
-    <exclude
-        domain="sharedpref"
-        path="SunriseClock.xml" />
-</full-backup-content>


### PR DESCRIPTION
Error message: `The attribute android:fullBackupContent is deprecated from Android 12 and higher and may be removed in future versions. Consider adding the attribute android:dataExtractionRules specifying an @xml resource which configures cloud backups and device transfers on Android 12 and higher.`

We do not need to explicitly exclude files from backups, therefore we can delete these settings. Backups are allowed by default and we currently do not profit from configuring them further.