### PR TITLE
Fix automatic ordering of imports

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -20,6 +20,13 @@
       <option name="ANNOTATION_PARAMETER_WRAP" value="1" />
       <option name="ALIGN_MULTILINE_ANNOTATION_PARAMETERS" value="true" />
       <option name="NEW_LINE_WHEN_BODY_IS_PRESENTED" value="true" />
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+        </value>
+      </option>
       <option name="JD_ADD_BLANK_AFTER_RETURN" value="true" />
       <option name="JD_KEEP_INVALID_TAGS" value="false" />
       <option name="JD_PRESERVE_LINE_FEEDS" value="true" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,7 +108,7 @@ spotless {
     java {
         target 'src/*/java/**/*.java'
         // Use the default importOrder configuration
-        // importOrder()
+        importOrder()
         removeUnusedImports()
         // apply a specific flavor of palantir-java-format
         leadingSpacesToTabs()


### PR DESCRIPTION
Previously Spottless would use a different import ordering than Android Studio. This is fixed with this change