### PR TITLE
Change CI to only run on PR or push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
-on: [ push ]
+on:
+  pull_request:
+  push:
+    branches: master
 jobs:
   Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previously the Build-CI would run on pushes to all branches. This isn't necessary, because they are not yet in state where a build check makes sense.