### PR TITLE
Fix light list reloading

### DIFF
--- a/.idea/inspectionProfiles/SunriseClock.xml
+++ b/.idea/inspectionProfiles/SunriseClock.xml
@@ -2,9 +2,8 @@
   <profile version="1.0">
     <option name="myName" value="SunriseClock" />
     <inspection_tool class="Anonymous2MethodRef" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="AnonymousHasLambdaAlternative" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CodeBlock2Expr" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="Convert2Lambda" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Convert2MethodRef" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SequencedCollectionMethodCanBeUsed" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/ui/light/LightsListAdapter.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/ui/light/LightsListAdapter.java
@@ -245,7 +245,7 @@ public class LightsListAdapter extends ListAdapter<ListItem, RecyclerView.ViewHo
             binding.setSliderTouchListener(new SliderTouchListener());
         }
 
-        void bind(UILight item) {
+        void bind(@NonNull UILight item) {
             bindName(item.getName());
             bindIsReachable(item.getIsReachable());
             bindIsSwitchable(item.getIsSwitchable());
@@ -294,6 +294,11 @@ public class LightsListAdapter extends ListAdapter<ListItem, RecyclerView.ViewHo
             @Override
             public void onCheckedChanged(final CompoundButton compoundButton, final boolean isChecked) {
                 UILight light = (UILight) getItem(getAbsoluteAdapterPosition());
+                if (light.getIsOn() == isChecked) {
+                    // This happens, when a viewHolder is reused and a new Light is bound to it.
+                    LogUtil.v("Suppressing on onCheckedChange event for light %d", light.getId());
+                    return;
+                }
                 clickListeners.onLightSwitchCheckedChange(light.getId(), isChecked);
             }
         }

--- a/app/src/main/java/org/d3kad3nt/sunriseClock/ui/light/LightsListAdapter.java
+++ b/app/src/main/java/org/d3kad3nt/sunriseClock/ui/light/LightsListAdapter.java
@@ -296,7 +296,7 @@ public class LightsListAdapter extends ListAdapter<ListItem, RecyclerView.ViewHo
                 UILight light = (UILight) getItem(getAbsoluteAdapterPosition());
                 if (light.getIsOn() == isChecked) {
                     // This happens, when a viewHolder is reused and a new Light is bound to it.
-                    LogUtil.v("Suppressing on onCheckedChange event for light %d", light.getId());
+                    LogUtil.v("Suppressing onCheckedChanged event for light %d.", light.getId());
                     return;
                 }
                 clickListeners.onLightSwitchCheckedChange(light.getId(), isChecked);


### PR DESCRIPTION
This happened because view holders got reused and if the checked State
of a light changed a onCheckedChanged event is fired.
Previously this would lead to an set request to the repository which is
now removed