### PR TITLE
Set Target SDK to 36

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'com.android.application'
 apply plugin: "androidx.navigation.safeargs"
 
 android {
-    compileSdk 35
+    compileSdk 36
     defaultConfig {
         applicationId "org.d3kad3nt.sunriseClock"
         minSdkVersion 21
-        targetSdk 35
+        targetSdk 36
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "org.d3kad3nt.sunriseClock.backend"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 21

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "org.d3kad3nt.sunriseClock.util"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 21


### PR DESCRIPTION
This is done by hand, because there is no Upgrade Assistant for SDK 36 even through it is already released.

The App compiles and basic functionality is tested.