### PR TITLE
update Dependabot search path for gradle files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
       - "/util"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "com.android.tools.build:gradle"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@
 version: 2
 updates:
   - package-ecosystem: "gradle" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directories:
+      - "/" # Location of root config
+      - "/app"
+      - "/backend"
+      - "/util"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This adds the new modules util and backend to folders where dependabot searches for dependencies. 
It also adds the app module for completeness, even through this module was already found by dependabot.
This also ignores Updates for gradle,  because most times these updates also need changes in gradle-wrapper.properties which is not handled by dependabot