### PR TITLE
Upgrade minSDK to 23

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ squareup-retrofit = "2.11.0"
 androidx-room = "2.6.1"
 
 # Android SDK
-minSdk = "21"
+minSdk = "23"
 targetSdk = "36"
 compileSdk = "36"
 


### PR DESCRIPTION
This is done so that current Android Jetpack versions (e.g. Room) can be
 used.
 See: https://developer.android.com/jetpack/androidx/versions#version-table